### PR TITLE
Prevent writing to changelog in dry run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.nyc_output
+coverage
+node_modules
+package-lock.json
+tmp

--- a/index.js
+++ b/index.js
@@ -54,11 +54,14 @@ class KeepAChangelog extends Plugin {
   }
 
   beforeRelease() {
-    const { version } = this.getContext();
-    const formattedDate = getFormattedDate();
-    const releaseTitle = `\n\n## [${version}] - ${formattedDate}\n\n`;
-    const changelog = this.changelogContent.replace(this.unreleasedTitle, releaseTitle);
-    fs.writeFileSync(this.changelogPath, changelog);
+    const { isDryRun } = this.global;
+    if (!isDryRun) {
+      const { version } = this.getContext();
+      const formattedDate = getFormattedDate();
+      const releaseTitle = `\n\n## [${version}] - ${formattedDate}\n\n`;
+      const changelog = this.changelogContent.replace(this.unreleasedTitle, releaseTitle);  
+      fs.writeFileSync(this.changelogPath, changelog);
+    }
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -55,13 +55,12 @@ class KeepAChangelog extends Plugin {
 
   beforeRelease() {
     const { isDryRun } = this.global;
-    if (!isDryRun) {
-      const { version } = this.getContext();
-      const formattedDate = getFormattedDate();
-      const releaseTitle = `\n\n## [${version}] - ${formattedDate}\n\n`;
-      const changelog = this.changelogContent.replace(this.unreleasedTitle, releaseTitle);  
-      fs.writeFileSync(this.changelogPath, changelog);
-    }
+    if (isDryRun) return;
+    const { version } = this.getContext();
+    const formattedDate = getFormattedDate();
+    const releaseTitle = `\n\n## [${version}] - ${formattedDate}\n\n`;
+    const changelog = this.changelogContent.replace(this.unreleasedTitle, releaseTitle);  
+    fs.writeFileSync(this.changelogPath, changelog);
   }
 }
 

--- a/test.js
+++ b/test.js
@@ -5,11 +5,13 @@ const mock = require('mock-fs');
 const { factory, runTasks } = require('release-it/test/util');
 const Plugin = require('.');
 
+const initialDryRunFileContents = '\n\n## [Unreleased]\n\n* Item A\n* Item B\n\n## [1.0.0] - 2020-05-02\n\n* Item C\n* Item D';
 mock({
   './CHANGELOG-FOO.md': '\n\n## [FOO]\n\n* Item A\n* Item B',
   './CHANGELOG-UNRELEASED.md': '\n\n## [Unreleased]\n\n* Item A\n* Item B',
   './CHANGELOG-EMPTY.md': '\n\n## [Unreleased]\n\n\n\n## [1.0.0]\n\n* Item A\n* Item B',
-  './CHANGELOG-FULL.md': '\n\n## [Unreleased]\n\n* Item A\n* Item B\n\n## [1.0.0] - 2020-05-02\n\n* Item C\n* Item D'
+  './CHANGELOG-FULL.md': '\n\n## [Unreleased]\n\n* Item A\n* Item B\n\n## [1.0.0] - 2020-05-02\n\n* Item C\n* Item D',
+  './CHANGELOG-DRYRUN.md': initialDryRunFileContents
 });
 
 const readFile = file => fs.readFileSync(file).toString().trim();
@@ -53,3 +55,14 @@ test('should write changelog', async t => {
     /## \[1\.0\.1\] - [0-9]{4}-[0-9]{2}-[0-9]{2}\n\n\* Item A\n\* Item B\n\n## \[1\.0\.0\] - 2020-05-02\n\n\* Item C\n*\* Item D/
   );
 });
+
+test('should not write changelog in dry run', async t => {
+  const options = { [namespace]: { filename: 'CHANGELOG-DRYRUN.md' } };
+  const plugin = factory(Plugin, { namespace, options, global: { isDryRun: true } });
+  await runTasks(plugin);
+  assert.equal(
+    fs.readFileSync('./CHANGELOG-DRYRUN.md').toString(),
+    initialDryRunFileContents
+  );
+});
+


### PR DESCRIPTION
Add support for honoring the `--dry-run` argument by not writing to the changelog.