### PR TITLE
Strict latest option and keep unreleased option

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,11 @@ In [release-it](https://github.com/release-it/release-it) config:
   }
 }
 ```
+
+## Options
+
+| option         | default value  | description                                                  |
+| -------------- | -------------- | ------------------------------------------------------------ |
+| filename       | `CHANGELOG.md` | File with changelogs.                                        |
+| strictLatest   | `true`         | Entry of latest version must be present in order to get correct changelog. Set this option to `false` if you expect latest version without logs. |
+| keepUnreleased | `false`        | It leaves "Unreleased" title row unchanged if set to `true`. |

--- a/test.js
+++ b/test.js
@@ -94,3 +94,10 @@ test('should not write changelog with keep unreleased option', async t => {
     initialDryRunFileContents
   );
 });
+
+test('should find changelog even if less new lines is used', async t => {
+  const options = { [namespace]: { filename: 'CHANGELOG-LESS_NEW_LINES.md' } };
+  const plugin = factory(Plugin, { namespace, options });
+  await runTasks(plugin);
+  assert.equal(plugin.getChangelog(), '* Item A\n* Item B');
+});


### PR DESCRIPTION
Added options:
- `strictLatest` - Entry of latest version must be present in order to get correct changelog. Set this option to `false` if you expect latest version without logs.
- `keepUnreleased` - It leaves "Unreleased" title row unchanged if set to `true`.

Changed that plugin does not force you to have so many new lines between version title and changelog entires.

Bugfix where changelog filename was not properly applied across the plugin.