### PR TITLE
Fix version URLs in gitlab repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,4 @@ In [release-it](https://github.com/release-it/release-it) config:
 | addUnreleased  | `false`        | It leaves "Unreleased" title row if set to `true`.                                                                                               |
 | keepUnreleased | `false`        | It leaves "Unreleased" title row unchanged if set to `true`.                                                                                     |
 | addVersionUrl  | `false`        | Links the version to the according changeset.                                                                                                    |
+| head  | `'HEAD'`        | The git revision the new version tag is compared to in the Unreleased URL.                                                                               |

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ In [release-it](https://github.com/release-it/release-it) config:
 
 | option         | default value  | description                                                                                                                                      |
 | -------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| filename       | `CHANGELOG.md` | File with changelogs.                                                                                                                            |
+| filename       | `'CHANGELOG.md'` | File with changelogs.                                                                                                                            |
 | strictLatest   | `true`         | Entry of latest version must be present in order to get correct changelog. Set this option to `false` if you expect latest version without logs. |
 | addUnreleased  | `false`        | It leaves "Unreleased" title row if set to `true`.                                                                                               |
 | keepUnreleased | `false`        | It leaves "Unreleased" title row unchanged if set to `true`.                                                                                     |

--- a/index.js
+++ b/index.js
@@ -13,13 +13,14 @@ const getFormattedDate = () => {
 class KeepAChangelog extends Plugin {
   async init() {
     await super.init();
-    const { filename, strictLatest, addUnreleased, keepUnreleased, addVersionUrl } = this.options;
+    const { filename, strictLatest, addUnreleased, keepUnreleased, addVersionUrl, head } = this.options;
 
     this.filename = filename || 'CHANGELOG.md';
     this.strictLatest = strictLatest === undefined ? true : Boolean(strictLatest);
     this.addUnreleased = addUnreleased === undefined ? false : Boolean(addUnreleased);
     this.keepUnreleased = keepUnreleased === undefined ? false : Boolean(keepUnreleased);
     this.addVersionUrl = addVersionUrl === undefined ? false : Boolean(addVersionUrl);
+    this.head = head || 'HEAD'
 
     this.changelogPath = path.resolve(this.filename);
     this.changelogContent = fs.readFileSync(this.changelogPath, 'utf-8');
@@ -72,10 +73,10 @@ class KeepAChangelog extends Plugin {
     const repositoryUrl = `https://${repo.host}/${repo.repository}`;
 
     // Add or update the Unreleased link
-    const unreleasedUrl = `${repositoryUrl}/compare/${tagName}...HEAD`;
+    const unreleasedUrl = `${repositoryUrl}/compare/${tagName}...${this.head}`;
     const unreleasedLink = `[Unreleased]: ${unreleasedUrl}`;
     if (updatedChangelog.includes('[Unreleased]:')) {
-      updatedChangelog = updatedChangelog.replace(/\[Unreleased\]\:.*HEAD/, unreleasedLink);
+      updatedChangelog = updatedChangelog.replace(new RegExp('\\[Unreleased\\]\\:.*' + this.head), unreleasedLink);
     } else {
       updatedChangelog = `${updatedChangelog}${this.EOL}${this.EOL}${unreleasedLink}`;
     }

--- a/test.js
+++ b/test.js
@@ -23,6 +23,8 @@ mock({
   './CHANGELOG-UNRELEASED.md': '## [Unreleased]\n\n* Item A\n* Item B\n\n## [1.0.0] - 2020-05-02\n\n* Item C\n* Item D',
   './CHANGELOG-VERSION_URL.md':
     '## [Unreleased]\n\n* Item A\n* Item B\n\n## [1.0.0] - 2020-05-02\n\n* Item C\n* Item D\n\n[Unreleased]: https://github.com/release-it/release-it/compare/1.0.0..HEAD\n[1.0.0]: https://github.com/release-it/release-it/compare/0.0.0...1.0.0',
+    './CHANGELOG-VERSION_URL_HEAD.md':
+      '## [Unreleased]\n\n* Item A\n* Item B\n\n## [1.0.0] - 2020-05-02\n\n* Item C\n* Item D\n\n[Unreleased]: https://github.com/release-it/release-it/compare/1.0.0..main\n[1.0.0]: https://github.com/release-it/release-it/compare/0.0.0...1.0.0',
   './CHANGELOG-VERSION_URL_UNRELEASED.md':
     '## [Unreleased]\n\n* Item A\n* Item B\n\n## [1.0.0] - 2020-05-02\n\n* Item C\n* Item D\n\n[Unreleased]: https://github.com/user/project/compare/1.0.0..HEAD\n[1.0.0]: https://github.com/user/project/compare/0.0.0...1.0.0',
   './CHANGELOG-VERSION_URL_NEW.md': '## [Unreleased]\n\n* Item A\n* Item B'
@@ -143,6 +145,24 @@ test('should add links to the end of the file', async t => {
   assert.match(
     readFile('./CHANGELOG-VERSION_URL.md'),
     /^## \[1\.0\.1] - [0-9]{4}-[0-9]{2}-[0-9]{2}\n\n\* Item A\n\* Item B\n\n## \[1\.0\.0] - 2020-05-02\n\n\* Item C\n*\* Item D\n\n\[Unreleased]: https:\/\/github\.com\/release-it\/release-it\/compare\/1\.0\.1\.\.\.HEAD\n\[1\.0\.1]: https:\/\/github\.com\/release-it\/release-it\/compare\/1\.0\.0\.\.\.1\.0\.1\n\[1\.0\.0]: https:\/\/github\.com\/release-it\/release-it\/compare\/0\.0\.0\.\.\.1\.0\.0\n$/
+  );
+});
+
+test('should add links with custom head to the end of the file', async t => {
+  const options = { [namespace]: { filename: 'CHANGELOG-VERSION_URL_HEAD.md', addVersionUrl: true, head: 'main' } };
+  const plugin = factory(Plugin, { namespace, options });
+  plugin.config.setContext({
+    latestTag: '1.0.0',
+    repo: {
+      host: 'github.com',
+      repository: 'release-it/release-it'
+    }
+  });
+  await runTasks(plugin);
+  assert.equal(plugin.getChangelog(), '* Item A\n* Item B');
+  assert.match(
+    readFile('./CHANGELOG-VERSION_URL_HEAD.md'),
+    /^## \[1\.0\.1] - [0-9]{4}-[0-9]{2}-[0-9]{2}\n\n\* Item A\n\* Item B\n\n## \[1\.0\.0] - 2020-05-02\n\n\* Item C\n*\* Item D\n\n\[Unreleased]: https:\/\/github\.com\/release-it\/release-it\/compare\/1\.0\.1\.\.\.main\n\[1\.0\.1]: https:\/\/github\.com\/release-it\/release-it\/compare\/1\.0\.0\.\.\.1\.0\.1\n\[1\.0\.0]: https:\/\/github\.com\/release-it\/release-it\/compare\/0\.0\.0\.\.\.1\.0\.0\n$/
   );
 });
 


### PR DESCRIPTION
In Gitlab, the compare tool doesn't accept HEAD in the revision range, only tags and branches are allowed. This PR adds the possibility to configure the name of the head revision in an additional plugin option, so the plugin can also generate version URLs for gitlab repos.

- Add head option, defaults to 'HEAD'
- Use the value of head option where HEAD was hardcoded before
- Add a test with custom head set to 'main'