### PR TITLE
Work with case-insensitive identifyers of link definition

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,8 +75,9 @@ class KeepAChangelog extends Plugin {
     // Add or update the Unreleased link
     const unreleasedUrl = `${repositoryUrl}/compare/${tagName}...${this.head}`;
     const unreleasedLink = `[Unreleased]: ${unreleasedUrl}`;
-    if (updatedChangelog.includes('[Unreleased]:')) {
-      updatedChangelog = updatedChangelog.replace(new RegExp('\\[Unreleased\\]\\:.*' + this.head), unreleasedLink);
+    const hasUnreleasedLink = /^\[(Unreleased)\]\: .*$/im
+    if (hasUnreleasedLink.test(updatedChangelog)) {
+      updatedChangelog = updatedChangelog.replace(hasUnreleasedLink, '[$1]: ' + unreleasedUrl);
     } else {
       updatedChangelog = `${updatedChangelog}${this.EOL}${this.EOL}${unreleasedLink}`;
     }


### PR DESCRIPTION
In the changelog files, the Unreleased link is normally referenced using the abbreviated syntax where the definition identifyer is concluded from the link text.
This also works with inconsistent case, so one can capitalize the link text and write the respective link definition identifyer in lower case.
This can be prescribed via styling rules, and Prettier converts definition identifyers to lower case, although this is an open issue and might be closed at some time.
The result might look like this:

```markdown
## [Unreleased]

[unreleased]: http://example.org
```

When it comes to replacing or adding the Unreleased link, this plugin only detects capitalized Unreleased link definitions.
It would be nice to have case-insensitive search here and reuse the identifyer if an Unreleased link definition is found.
I have created a fix using case-insensitive RegExp which captures the identifyer and reinserts it in the replacement string.
