### PR TITLE
Better support for GitLab

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,10 @@ In [release-it](https://github.com/release-it/release-it) config:
 
 | option         | default value  | description                                                                                                                                      |
 | -------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| filename       | `'CHANGELOG.md'` | File with changelogs.                                                                                                                            |
+| filename       | `'CHANGELOG.md'` | File with changelogs.                                                                                                                          |
 | strictLatest   | `true`         | Entry of latest version must be present in order to get correct changelog. Set this option to `false` if you expect latest version without logs. |
 | addUnreleased  | `false`        | It leaves "Unreleased" title row if set to `true`.                                                                                               |
 | keepUnreleased | `false`        | It leaves "Unreleased" title row unchanged if set to `true`.                                                                                     |
 | addVersionUrl  | `false`        | Links the version to the according changeset.                                                                                                    |
-| head  | `'HEAD'`        | The git revision the new version tag is compared to in the Unreleased URL.                                                                               |
+| head           | `'HEAD'`       | The git revision the new version tag is compared to in the Unreleased URL.                                                                       |
+| isGitLab       | `'auto'`       | Is repository hosted on GitLab? `true` or `false` or `auto`. If `auto` it assumes `true` if it finds `gitlab` inside repository's hostname.      |

--- a/test.js
+++ b/test.js
@@ -27,7 +27,13 @@ mock({
       '## [Unreleased]\n\n* Item A\n* Item B\n\n## [1.0.0] - 2020-05-02\n\n* Item C\n* Item D\n\n[Unreleased]: https://github.com/release-it/release-it/compare/1.0.0..main\n[1.0.0]: https://github.com/release-it/release-it/compare/0.0.0...1.0.0',
   './CHANGELOG-VERSION_URL_UNRELEASED.md':
     '## [Unreleased]\n\n* Item A\n* Item B\n\n## [1.0.0] - 2020-05-02\n\n* Item C\n* Item D\n\n[Unreleased]: https://github.com/user/project/compare/1.0.0..HEAD\n[1.0.0]: https://github.com/user/project/compare/0.0.0...1.0.0',
-  './CHANGELOG-VERSION_URL_NEW.md': '## [Unreleased]\n\n* Item A\n* Item B'
+  './CHANGELOG-VERSION_URL_NEW.md': '## [Unreleased]\n\n* Item A\n* Item B',
+  './CHANGELOG-VERSION_GITLAB_AUTO.md':
+    '## [Unreleased]\n\n* Item A\n* Item B\n\n## [1.0.0] - 2020-05-02\n\n* Item C\n* Item D\n\n[Unreleased]: https://gitlab.com/release-it/release-it/-/compare/1.0.0..HEAD\n[1.0.0]: https://gitlab.com/release-it/release-it/-/compare/0.0.0...1.0.0',
+    './CHANGELOG-VERSION_GITLAB.md':
+    '## [Unreleased]\n\n* Item A\n* Item B\n\n## [1.0.0] - 2020-05-02\n\n* Item C\n* Item D\n\n[Unreleased]: https://gitlab.com/release-it/release-it/-/compare/1.0.0..HEAD\n[1.0.0]: https://gitlab.com/release-it/release-it/-/compare/0.0.0...1.0.0',
+    './CHANGELOG-VERSION_OLD_GITLAB.md':
+    '## [Unreleased]\n\n* Item A\n* Item B\n\n## [1.0.0] - 2020-05-02\n\n* Item C\n* Item D\n\n[Unreleased]: https://gitlab.com/release-it/release-it/compare/1.0.0..HEAD\n[1.0.0]: https://gitlab.com/release-it/release-it/compare/0.0.0...1.0.0',
 });
 
 const readFile = file => fs.readFileSync(file).toString();
@@ -204,5 +210,59 @@ test('should add link to the end of a new changelog', async t => {
   assert.match(
     readFile('./CHANGELOG-VERSION_URL_NEW.md'),
     /^## \[1\.0\.0] - [0-9]{4}-[0-9]{2}-[0-9]{2}\n\n\* Item A\n\* Item B\n\n\[Unreleased]: https:\/\/github\.com\/user\/project\/compare\/1\.0\.0\.\.\.HEAD\n\[1.0.0]: https:\/\/github\.com\/user\/project\/compare\/0\.0\.0\.\.\.1\.0\.0\n$/
+  );
+});
+
+test('should add links to the end of the file for GitLab automatically', async t => {
+  const options = { [namespace]: { filename: 'CHANGELOG-VERSION_GITLAB_AUTO.md', addVersionUrl: true } };
+  const plugin = factory(Plugin, { namespace, options });
+  plugin.config.setContext({
+    latestTag: '1.0.0',
+    repo: {
+      host: 'gitlab.com',
+      repository: 'release-it/release-it'
+    }
+  });
+  await runTasks(plugin);
+  assert.equal(plugin.getChangelog(), '* Item A\n* Item B');
+  assert.match(
+    readFile('./CHANGELOG-VERSION_GITLAB_AUTO.md'),
+    /^## \[1\.0\.1] - [0-9]{4}-[0-9]{2}-[0-9]{2}\n\n\* Item A\n\* Item B\n\n## \[1\.0\.0] - 2020-05-02\n\n\* Item C\n*\* Item D\n\n\[Unreleased]: https:\/\/gitlab\.com\/release-it\/release-it\/-\/compare\/1\.0\.1\.\.\.HEAD\n\[1\.0\.1]: https:\/\/gitlab\.com\/release-it\/release-it\/-\/compare\/1\.0\.0\.\.\.1\.0\.1\n\[1\.0\.0]: https:\/\/gitlab\.com\/release-it\/release-it\/-\/compare\/0\.0\.0\.\.\.1\.0\.0\n$/
+  );
+});
+
+test('should add links to the end of the file for GitLab explicitly', async t => {
+  const options = { [namespace]: { filename: 'CHANGELOG-VERSION_GITLAB.md', addVersionUrl: true, isGitLab: true } };
+  const plugin = factory(Plugin, { namespace, options });
+  plugin.config.setContext({
+    latestTag: '1.0.0',
+    repo: {
+      host: 'example.com',
+      repository: 'release-it/release-it'
+    }
+  });
+  await runTasks(plugin);
+  assert.equal(plugin.getChangelog(), '* Item A\n* Item B');
+  assert.match(
+    readFile('./CHANGELOG-VERSION_GITLAB.md'),
+    /^## \[1\.0\.1] - [0-9]{4}-[0-9]{2}-[0-9]{2}\n\n\* Item A\n\* Item B\n\n## \[1\.0\.0] - 2020-05-02\n\n\* Item C\n*\* Item D\n\n\[Unreleased]: https:\/\/example\.com\/release-it\/release-it\/-\/compare\/1\.0\.1\.\.\.HEAD\n\[1\.0\.1]: https:\/\/example\.com\/release-it\/release-it\/-\/compare\/1\.0\.0\.\.\.1\.0\.1\n\[1\.0\.0]: https:\/\/gitlab\.com\/release-it\/release-it\/-\/compare\/0\.0\.0\.\.\.1\.0\.0\n$/
+  );
+});
+
+test('should add links to the end of the file for old GitLab', async t => {
+  const options = { [namespace]: { filename: 'CHANGELOG-VERSION_OLD_GITLAB.md', addVersionUrl: true, isGitLab: false } };
+  const plugin = factory(Plugin, { namespace, options });
+  plugin.config.setContext({
+    latestTag: '1.0.0',
+    repo: {
+      host: 'gitlab.com',
+      repository: 'release-it/release-it'
+    }
+  });
+  await runTasks(plugin);
+  assert.equal(plugin.getChangelog(), '* Item A\n* Item B');
+  assert.match(
+    readFile('./CHANGELOG-VERSION_OLD_GITLAB.md'),
+    /^## \[1\.0\.1] - [0-9]{4}-[0-9]{2}-[0-9]{2}\n\n\* Item A\n\* Item B\n\n## \[1\.0\.0] - 2020-05-02\n\n\* Item C\n*\* Item D\n\n\[Unreleased]: https:\/\/gitlab\.com\/release-it\/release-it\/compare\/1\.0\.1\.\.\.HEAD\n\[1\.0\.1]: https:\/\/gitlab\.com\/release-it\/release-it\/compare\/1\.0\.0\.\.\.1\.0\.1\n\[1\.0\.0]: https:\/\/gitlab\.com\/release-it\/release-it\/compare\/0\.0\.0\.\.\.1\.0\.0\n$/
   );
 });


### PR DESCRIPTION
So GitLab has in fact `-` inside `changes` URL, e.g.:

```
https://gitlab.com/release-it/release-it/-/compare/1.0.0..HEAD
```

So I added an option to detect this automatically or enable/disable it explicitly.