### PR TITLE
Fix: Don't update changelog when `--no-increment` flag is set

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,12 @@ class KeepAChangelog extends Plugin {
   }
 
   getChangelog(latestVersion) {
+    const { isIncrement } = this.config;
+    // Return the unchanged changelog content when no increment is made
+    if (!isIncrement) {
+      return this.changelogContent;
+    }
+
     const { changelog } = this.getContext();
     if (changelog) return changelog;
 
@@ -94,8 +100,8 @@ class KeepAChangelog extends Plugin {
 
   beforeRelease() {
     const { addUnreleased, keepUnreleased, addVersionUrl } = this;
-    const { isDryRun } = this.config;
-    if (isDryRun || keepUnreleased) return;
+    const { isDryRun, isIncrement } = this.config;
+    if (isDryRun || keepUnreleased || !isIncrement) return;
     const { version } = this.getContext();
     const formattedDate = getFormattedDate();
     const unreleasedTitle = addUnreleased ? this.unreleasedTitle + this.EOL + this.EOL : '';

--- a/test.js
+++ b/test.js
@@ -52,6 +52,13 @@ test('should throw for empty "unreleased" section', async t => {
   await assert.rejects(runTasks(plugin), /There are no entries under "Unreleased" section in CHANGELOG-EMPTY\.md/);
 });
 
+test('should not throw for empty "unreleased" section when no-increment flag is set', async t => {
+  const options = { 'increment': false, [namespace]: { filename: 'CHANGELOG-EMPTY.md' } };
+  const plugin = factory(Plugin, { namespace, options });
+  await runTasks(plugin);
+  assert.equal(plugin.getChangelog(), readFile('./CHANGELOG-EMPTY.md'))
+});
+
 test('should throw for missing section for previous release', async t => {
   const options = { [namespace]: { filename: 'CHANGELOG-MISSING.md' } };
   const plugin = factory(Plugin, { namespace, options });


### PR DESCRIPTION
As described in #22, this prevents the plugin from making any changes to the changelog when the `--no-increment` flag is set.

Fixes #22.