### PR TITLE
Add options for customising version URL format

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,6 @@
   "singleQuote": true,
   "endOfLine": "lf",
   "printWidth": 125,
-  "arrowParens": "avoid"
+  "arrowParens": "avoid",
+  "trailingComma": "none"
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "singleQuote": true,
+  "endOfLine": "lf",
+  "printWidth": 125,
+  "arrowParens": "avoid"
+}

--- a/README.md
+++ b/README.md
@@ -33,6 +33,24 @@ In [release-it](https://github.com/release-it/release-it) config:
 
 ### versionUrlFormats
 
+The URL formats used when `addVersionUrl` is set to `true`. Example configuration for a repository in Azure DevOps:
+
+```json
+"plugins": {
+  "@release-it/keep-a-changelog": {
+    "filename": "CHANGELOG.md",
+    "head": "main",
+    "addVersionUrl": true,
+    "versionUrlFormats": {
+      "repositoryUrl": "https://dev.azure.com/...",
+      "unreleasedUrl": "{repositoryUrl}/branchCompare?baseVersion=GT{tagName}&targetVersion=GB{head}",
+      "versionUrl": "{repositoryUrl}/branchCompare?baseVersion=GT{previousTag}&targetVersion=GT{tagName}",
+      "firstVersionUrl": "{repositoryUrl}?version=GT{tagName}"
+    }
+  }
+}
+```
+
 | option          | default value                                         | description                                                                                 |
 | --------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------- |
 | repositoryUrl   | `'https://{host}/{repository}'`                       | The format of the repository URL.                                                           |

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ In [release-it](https://github.com/release-it/release-it) config:
 
 ## Options
 
-| option         | default value  | description                                                                                                                                      |
-| -------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| option         | default value    | description                                                                                                                                      |
+| -------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
 | filename       | `'CHANGELOG.md'` | File with changelogs.                                                                                                                            |
-| strictLatest   | `true`         | Entry of latest version must be present in order to get correct changelog. Set this option to `false` if you expect latest version without logs. |
-| addUnreleased  | `false`        | It leaves "Unreleased" title row if set to `true`.                                                                                               |
-| keepUnreleased | `false`        | It leaves "Unreleased" title row unchanged if set to `true`.                                                                                     |
-| addVersionUrl  | `false`        | Links the version to the according changeset.                                                                                                    |
-| head  | `'HEAD'`        | The git revision the new version tag is compared to in the Unreleased URL.                                                                               |
+| strictLatest   | `true`           | Entry of latest version must be present in order to get correct changelog. Set this option to `false` if you expect latest version without logs. |
+| addUnreleased  | `false`          | It leaves "Unreleased" title row if set to `true`.                                                                                               |
+| keepUnreleased | `false`          | It leaves "Unreleased" title row unchanged if set to `true`.                                                                                     |
+| addVersionUrl  | `false`          | Links the version to the according changeset.                                                                                                    |
+| head           | `'HEAD'`         | The git revision the new version tag is compared to in the Unreleased URL.                                                                       |

--- a/README.md
+++ b/README.md
@@ -21,15 +21,21 @@ In [release-it](https://github.com/release-it/release-it) config:
 
 ## Options
 
-| option                     | default value                                         | description                                                                                                                                      |
-| -------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| filename                   | `'CHANGELOG.md'`                                      | File with changelogs.                                                                                                                            |
-| strictLatest               | `true`                                                | Entry of latest version must be present in order to get correct changelog. Set this option to `false` if you expect latest version without logs. |
-| addUnreleased              | `false`                                               | It leaves "Unreleased" title row if set to `true`.                                                                                               |
-| keepUnreleased             | `false`                                               | It leaves "Unreleased" title row unchanged if set to `true`.                                                                                     |
-| addVersionUrl              | `false`                                               | Links the version to the according changeset. Uses GitHub-compatible URLs by default, see other options to configure the URL format.             |
-| repositoryUrlFormat        | `'https://{host}/{repository}'`                       | The format of the repository URL. Used when `addVersionUrl` is set to `true`.                                                                    |
-| unreleasedVersionUrlFormat | `'{repositoryUrl}/compare/{tagName}...{head}'`        | The format of the `[unreleased]` section URL. Used when `addVersionUrl` is set to `true`.                                                        |
-| releasedVersionUrlFormat   | `'{repositoryUrl}/compare/{previousTag}...{tagName}'` | The format of a release version URL. Used when `addVersionUrl` is set to `true`.                                                                 |
-| firstVersionUrlFormat      | `'{repositoryUrl}/releases/tag/{tagName}'`            | The format of the first release version URL, i.e. when no previous tags have been released. Used when `addVersionUrl` is set to `true`.          |
-| head                       | `'HEAD'`                                              | The git revision the new version tag is compared to in the Unreleased URL.                                                                       |
+| option            | default value    | description                                                                                                                                      |
+| ----------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| filename          | `'CHANGELOG.md'` | File with changelogs.                                                                                                                            |
+| strictLatest      | `true`           | Entry of latest version must be present in order to get correct changelog. Set this option to `false` if you expect latest version without logs. |
+| addUnreleased     | `false`          | It leaves "Unreleased" title row if set to `true`.                                                                                               |
+| keepUnreleased    | `false`          | It leaves "Unreleased" title row unchanged if set to `true`.                                                                                     |
+| addVersionUrl     | `false`          | Links the version to the according changeset. Uses GitHub-compatible URLs by default, see other options to configure the URL format.             |
+| versionUrlFormats | See below.       | Determines the version URL format when `addVersionUrl` is set to `true`. Uses GitHub-compatible URLs by default.                                 |
+| head              | `'HEAD'`         | The git revision the new version tag is compared to in the Unreleased URL.                                                                       |
+
+### versionUrlFormats
+
+| option          | default value                                         | description                                                                                 |
+| --------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| repositoryUrl   | `'https://{host}/{repository}'`                       | The format of the repository URL.                                                           |
+| unreleasedUrl   | `'{repositoryUrl}/compare/{tagName}...{head}'`        | The format of the `[unreleased]` section URL.                                               |
+| versionUrl      | `'{repositoryUrl}/compare/{previousTag}...{tagName}'` | The format of a release version URL.                                                        |
+| firstVersionUrl | `'{repositoryUrl}/releases/tag/{tagName}'`            | The format of the first release version URL, i.e. when no previous tags have been released. |

--- a/README.md
+++ b/README.md
@@ -21,11 +21,15 @@ In [release-it](https://github.com/release-it/release-it) config:
 
 ## Options
 
-| option         | default value    | description                                                                                                                                      |
-| -------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| filename       | `'CHANGELOG.md'` | File with changelogs.                                                                                                                            |
-| strictLatest   | `true`           | Entry of latest version must be present in order to get correct changelog. Set this option to `false` if you expect latest version without logs. |
-| addUnreleased  | `false`          | It leaves "Unreleased" title row if set to `true`.                                                                                               |
-| keepUnreleased | `false`          | It leaves "Unreleased" title row unchanged if set to `true`.                                                                                     |
-| addVersionUrl  | `false`          | Links the version to the according changeset.                                                                                                    |
-| head           | `'HEAD'`         | The git revision the new version tag is compared to in the Unreleased URL.                                                                       |
+| option                     | default value                                         | description                                                                                                                                      |
+| -------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| filename                   | `'CHANGELOG.md'`                                      | File with changelogs.                                                                                                                            |
+| strictLatest               | `true`                                                | Entry of latest version must be present in order to get correct changelog. Set this option to `false` if you expect latest version without logs. |
+| addUnreleased              | `false`                                               | It leaves "Unreleased" title row if set to `true`.                                                                                               |
+| keepUnreleased             | `false`                                               | It leaves "Unreleased" title row unchanged if set to `true`.                                                                                     |
+| addVersionUrl              | `false`                                               | Links the version to the according changeset. Uses GitHub-compatible URLs by default, see other options to configure the URL format.             |
+| repositoryUrlFormat        | `'https://{host}/{repository}'`                       | The format of the repository URL. Used when `addVersionUrl` is set to `true`.                                                                    |
+| unreleasedVersionUrlFormat | `'{repositoryUrl}/compare/{tagName}...{head}'`        | The format of the `[unreleased]` section URL. Used when `addVersionUrl` is set to `true`.                                                        |
+| releasedVersionUrlFormat   | `'{repositoryUrl}/compare/{previousTag}...{tagName}'` | The format of a release version URL. Used when `addVersionUrl` is set to `true`.                                                                 |
+| firstVersionUrlFormat      | `'{repositoryUrl}/releases/tag/{tagName}'`            | The format of the first release version URL, i.e. when no previous tags have been released. Used when `addVersionUrl` is set to `true`.          |
+| head                       | `'HEAD'`                                              | The git revision the new version tag is compared to in the Unreleased URL.                                                                       |

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ class KeepAChangelog extends Plugin {
     this.addUnreleased = addUnreleased === undefined ? false : Boolean(addUnreleased);
     this.keepUnreleased = keepUnreleased === undefined ? false : Boolean(keepUnreleased);
     this.addVersionUrl = addVersionUrl === undefined ? false : Boolean(addVersionUrl);
-    this.head = head || 'HEAD'
+    this.head = head || 'HEAD';
 
     this.changelogPath = path.resolve(this.filename);
     this.changelogContent = fs.readFileSync(this.changelogPath, 'utf-8');
@@ -71,14 +71,22 @@ class KeepAChangelog extends Plugin {
     let updatedChangelog = changelog;
 
     const repositoryUrl = `https://${repo.host}/${repo.repository}`;
+    const unreleasedLinkRegex = new RegExp(`\\[unreleased\\]\\:.*${this.head}`, 'i');
 
     // Add or update the Unreleased link
     const unreleasedUrl = `${repositoryUrl}/compare/${tagName}...${this.head}`;
-    const unreleasedLink = `[Unreleased]: ${unreleasedUrl}`;
-    if (updatedChangelog.includes('[Unreleased]:')) {
-      updatedChangelog = updatedChangelog.replace(new RegExp('\\[Unreleased\\]\\:.*' + this.head), unreleasedLink);
+    const unreleasedLink = `[unreleased]: ${unreleasedUrl}`;
+    if (unreleasedLinkRegex.test(updatedChangelog)) {
+      updatedChangelog = updatedChangelog.replace(unreleasedLinkRegex, unreleasedLink);
     } else {
-      updatedChangelog = `${updatedChangelog}${this.EOL}${this.EOL}${unreleasedLink}`;
+      updatedChangelog = `${updatedChangelog}${this.EOL}${unreleasedLink}`;
+    }
+
+    // Add a link for the first tagged version
+    if (!latestTag) {
+      const firstVersionUrl = `${repositoryUrl}/releases/tag/${tagName}`;
+      const firstVersionLink = `[${version}]: ${firstVersionUrl}`;
+      return `${updatedChangelog}${this.EOL}${firstVersionLink}`;
     }
 
     // Add a link for the new version

--- a/package.json
+++ b/package.json
@@ -35,11 +35,11 @@
   "devDependencies": {
     "bron": "^1.1.1",
     "mock-fs": "^5.0.0",
-    "release-it": "^14.8.0",
+    "release-it": "^14.13.1",
     "sinon": "^11.1.1"
   },
   "peerDependencies": {
-    "release-it": "^14.8.0"
+    "release-it": "^14.13.1"
   },
   "engines": {
     "node": ">=10"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "url": "https://webpro.nl"
   },
   "dependencies": {
-    "detect-newline": "^3.1.0"
+    "detect-newline": "^3.1.0",
+    "string-template": "^1.0.0"
   },
   "devDependencies": {
     "bron": "^1.1.1",

--- a/test.js
+++ b/test.js
@@ -29,6 +29,8 @@ mock({
     '## [Unreleased]\n\n* Item A\n* Item B\n\n## [1.0.0] - 2020-05-02\n\n* Item C\n* Item D\n\n[unreleased]: https://github.com/release-it/release-it/compare/1.0.0..main\n[1.0.0]: https://github.com/release-it/release-it/compare/0.0.0...1.0.0',
   './CHANGELOG-VERSION_URL_UNRELEASED.md':
     '## [Unreleased]\n\n* Item A\n* Item B\n\n## [1.0.0] - 2020-05-02\n\n* Item C\n* Item D\n\n[unreleased]: https://github.com/user/project/compare/1.0.0..HEAD\n[1.0.0]: https://github.com/user/project/compare/0.0.0...1.0.0',
+  './CHANGELOG-VERSION_URL_UNRELEASED_TITLE_CASE.md':
+    '## [Unreleased]\n\n* Item A\n* Item B\n\n## [1.0.0] - 2020-05-02\n\n* Item C\n* Item D\n\n[Unreleased]: https://github.com/user/project/compare/1.0.0..HEAD\n[1.0.0]: https://github.com/user/project/compare/0.0.0...1.0.0',
   './CHANGELOG-VERSION_URL_NEW.md': '## [Unreleased]\n\n* Item A\n* Item B\n'
 });
 
@@ -223,13 +225,33 @@ test('should add unreleased section and links to the end of the file', async t =
   );
 });
 
+test('should match an existing unreleased link in title case', async t => {
+  const options = {
+    [namespace]: { filename: 'CHANGELOG-VERSION_URL_UNRELEASED_TITLE_CASE.md', addVersionUrl: true, addUnreleased: true }
+  };
+  const plugin = factory(Plugin, { namespace, options });
+  plugin.config.setContext({
+    latestTag: '1.0.0',
+    repo: {
+      host: 'github.com',
+      repository: 'user/project'
+    }
+  });
+  await runTasks(plugin);
+  assert.equal(plugin.getChangelog(), '* Item A\n* Item B');
+  assert.match(
+    readFile('./CHANGELOG-VERSION_URL_UNRELEASED_TITLE_CASE.md'),
+    /^## \[Unreleased]\n\n## \[1\.0\.1] - [0-9]{4}-[0-9]{2}-[0-9]{2}\n\n\* Item A\n\* Item B\n\n## \[1\.0\.0] - 2020-05-02\n\n\* Item C\n*\* Item D\n\n\[unreleased]: https:\/\/github\.com\/user\/project\/compare\/1\.0\.1\.\.\.HEAD\n\[1\.0\.1]: https:\/\/github\.com\/user\/project\/compare\/1\.0\.0\.\.\.1\.0\.1\n\[1\.0\.0]: https:\/\/github\.com\/user\/project\/compare\/0\.0\.0\.\.\.1\.0\.0\n/
+  );
+});
+
 // This test requires a change to runTasks, as it doesn't currently allow latestTag to be undefined/null.
-test.skip('should add links to the end of a new changelog', async t => {
+test('should add links to the end of a new changelog', async t => {
   const options = {
     [namespace]: { filename: 'CHANGELOG-VERSION_URL_NEW.md', addVersionUrl: true, strictLatest: false }
   };
   const plugin = factory(Plugin, { namespace, options });
-  sinon.stub(plugin, 'getLatestVersion').returns(undefined);
+  sinon.stub(plugin, 'getLatestVersion').returns('0.0.0');
   plugin.config.setContext({
     latestTag: undefined,
     increment: 'major',

--- a/test.js
+++ b/test.js
@@ -22,12 +22,12 @@ mock({
     '\r\n\r\n## [Unreleased]\r\n\r\n* Item A\r\n* Item B\r\n\r\n## [1.0.0] - 2020-05-02\r\n\r\n* Item C\r\n* Item D',
   './CHANGELOG-UNRELEASED.md': '## [Unreleased]\n\n* Item A\n* Item B\n\n## [1.0.0] - 2020-05-02\n\n* Item C\n* Item D',
   './CHANGELOG-VERSION_URL.md':
-    '## [Unreleased]\n\n* Item A\n* Item B\n\n## [1.0.0] - 2020-05-02\n\n* Item C\n* Item D\n\n[Unreleased]: https://github.com/release-it/release-it/compare/1.0.0..HEAD\n[1.0.0]: https://github.com/release-it/release-it/compare/0.0.0...1.0.0',
-    './CHANGELOG-VERSION_URL_HEAD.md':
-      '## [Unreleased]\n\n* Item A\n* Item B\n\n## [1.0.0] - 2020-05-02\n\n* Item C\n* Item D\n\n[Unreleased]: https://github.com/release-it/release-it/compare/1.0.0..main\n[1.0.0]: https://github.com/release-it/release-it/compare/0.0.0...1.0.0',
+    '## [Unreleased]\n\n* Item A\n* Item B\n\n## [1.0.0] - 2020-05-02\n\n* Item C\n* Item D\n\n[unreleased]: https://github.com/release-it/release-it/compare/1.0.0..HEAD\n[1.0.0]: https://github.com/release-it/release-it/compare/0.0.0...1.0.0',
+  './CHANGELOG-VERSION_URL_HEAD.md':
+    '## [Unreleased]\n\n* Item A\n* Item B\n\n## [1.0.0] - 2020-05-02\n\n* Item C\n* Item D\n\n[unreleased]: https://github.com/release-it/release-it/compare/1.0.0..main\n[1.0.0]: https://github.com/release-it/release-it/compare/0.0.0...1.0.0',
   './CHANGELOG-VERSION_URL_UNRELEASED.md':
-    '## [Unreleased]\n\n* Item A\n* Item B\n\n## [1.0.0] - 2020-05-02\n\n* Item C\n* Item D\n\n[Unreleased]: https://github.com/user/project/compare/1.0.0..HEAD\n[1.0.0]: https://github.com/user/project/compare/0.0.0...1.0.0',
-  './CHANGELOG-VERSION_URL_NEW.md': '## [Unreleased]\n\n* Item A\n* Item B'
+    '## [Unreleased]\n\n* Item A\n* Item B\n\n## [1.0.0] - 2020-05-02\n\n* Item C\n* Item D\n\n[unreleased]: https://github.com/user/project/compare/1.0.0..HEAD\n[1.0.0]: https://github.com/user/project/compare/0.0.0...1.0.0',
+  './CHANGELOG-VERSION_URL_NEW.md': '## [Unreleased]\n\n* Item A\n* Item B\n'
 });
 
 const readFile = file => fs.readFileSync(file).toString();
@@ -144,7 +144,7 @@ test('should add links to the end of the file', async t => {
   assert.equal(plugin.getChangelog(), '* Item A\n* Item B');
   assert.match(
     readFile('./CHANGELOG-VERSION_URL.md'),
-    /^## \[1\.0\.1] - [0-9]{4}-[0-9]{2}-[0-9]{2}\n\n\* Item A\n\* Item B\n\n## \[1\.0\.0] - 2020-05-02\n\n\* Item C\n*\* Item D\n\n\[Unreleased]: https:\/\/github\.com\/release-it\/release-it\/compare\/1\.0\.1\.\.\.HEAD\n\[1\.0\.1]: https:\/\/github\.com\/release-it\/release-it\/compare\/1\.0\.0\.\.\.1\.0\.1\n\[1\.0\.0]: https:\/\/github\.com\/release-it\/release-it\/compare\/0\.0\.0\.\.\.1\.0\.0\n$/
+    /^## \[1\.0\.1] - [0-9]{4}-[0-9]{2}-[0-9]{2}\n\n\* Item A\n\* Item B\n\n## \[1\.0\.0] - 2020-05-02\n\n\* Item C\n*\* Item D\n\n\[unreleased]: https:\/\/github\.com\/release-it\/release-it\/compare\/1\.0\.1\.\.\.HEAD\n\[1\.0\.1]: https:\/\/github\.com\/release-it\/release-it\/compare\/1\.0\.0\.\.\.1\.0\.1\n\[1\.0\.0]: https:\/\/github\.com\/release-it\/release-it\/compare\/0\.0\.0\.\.\.1\.0\.0\n$/
   );
 });
 
@@ -162,7 +162,7 @@ test('should add links with custom head to the end of the file', async t => {
   assert.equal(plugin.getChangelog(), '* Item A\n* Item B');
   assert.match(
     readFile('./CHANGELOG-VERSION_URL_HEAD.md'),
-    /^## \[1\.0\.1] - [0-9]{4}-[0-9]{2}-[0-9]{2}\n\n\* Item A\n\* Item B\n\n## \[1\.0\.0] - 2020-05-02\n\n\* Item C\n*\* Item D\n\n\[Unreleased]: https:\/\/github\.com\/release-it\/release-it\/compare\/1\.0\.1\.\.\.main\n\[1\.0\.1]: https:\/\/github\.com\/release-it\/release-it\/compare\/1\.0\.0\.\.\.1\.0\.1\n\[1\.0\.0]: https:\/\/github\.com\/release-it\/release-it\/compare\/0\.0\.0\.\.\.1\.0\.0\n$/
+    /^## \[1\.0\.1] - [0-9]{4}-[0-9]{2}-[0-9]{2}\n\n\* Item A\n\* Item B\n\n## \[1\.0\.0] - 2020-05-02\n\n\* Item C\n*\* Item D\n\n\[unreleased]: https:\/\/github\.com\/release-it\/release-it\/compare\/1\.0\.1\.\.\.main\n\[1\.0\.1]: https:\/\/github\.com\/release-it\/release-it\/compare\/1\.0\.0\.\.\.1\.0\.1\n\[1\.0\.0]: https:\/\/github\.com\/release-it\/release-it\/compare\/0\.0\.0\.\.\.1\.0\.0\n$/
   );
 });
 
@@ -182,17 +182,18 @@ test('should add unreleased section and links to the end of the file', async t =
   assert.equal(plugin.getChangelog(), '* Item A\n* Item B');
   assert.match(
     readFile('./CHANGELOG-VERSION_URL_UNRELEASED.md'),
-    /^## \[Unreleased]\n\n## \[1\.0\.1] - [0-9]{4}-[0-9]{2}-[0-9]{2}\n\n\* Item A\n\* Item B\n\n## \[1\.0\.0] - 2020-05-02\n\n\* Item C\n*\* Item D\n\n\[Unreleased]: https:\/\/github\.com\/user\/project\/compare\/1\.0\.1\.\.\.HEAD\n\[1\.0\.1]: https:\/\/github\.com\/user\/project\/compare\/1\.0\.0\.\.\.1\.0\.1\n\[1\.0\.0]: https:\/\/github\.com\/user\/project\/compare\/0\.0\.0\.\.\.1\.0\.0\n/
+    /^## \[Unreleased]\n\n## \[1\.0\.1] - [0-9]{4}-[0-9]{2}-[0-9]{2}\n\n\* Item A\n\* Item B\n\n## \[1\.0\.0] - 2020-05-02\n\n\* Item C\n*\* Item D\n\n\[unreleased]: https:\/\/github\.com\/user\/project\/compare\/1\.0\.1\.\.\.HEAD\n\[1\.0\.1]: https:\/\/github\.com\/user\/project\/compare\/1\.0\.0\.\.\.1\.0\.1\n\[1\.0\.0]: https:\/\/github\.com\/user\/project\/compare\/0\.0\.0\.\.\.1\.0\.0\n/
   );
 });
 
-test('should add link to the end of a new changelog', async t => {
+test.only('should add links to the end of a new changelog', async t => {
   const options = {
     [namespace]: { filename: 'CHANGELOG-VERSION_URL_NEW.md', addVersionUrl: true, strictLatest: false }
   };
   const plugin = factory(Plugin, { namespace, options });
-  sinon.stub(plugin, 'getLatestVersion').returns('0.0.0');
+  sinon.stub(plugin, 'getLatestVersion').returns(undefined);
   plugin.config.setContext({
+    latestTag: undefined,
     increment: 'major',
     repo: {
       host: 'github.com',
@@ -203,6 +204,6 @@ test('should add link to the end of a new changelog', async t => {
   assert.equal(plugin.getChangelog(), '* Item A\n* Item B');
   assert.match(
     readFile('./CHANGELOG-VERSION_URL_NEW.md'),
-    /^## \[1\.0\.0] - [0-9]{4}-[0-9]{2}-[0-9]{2}\n\n\* Item A\n\* Item B\n\n\[Unreleased]: https:\/\/github\.com\/user\/project\/compare\/1\.0\.0\.\.\.HEAD\n\[1.0.0]: https:\/\/github\.com\/user\/project\/compare\/0\.0\.0\.\.\.1\.0\.0\n$/
+    /^## \[1\.0\.0] - [0-9]{4}-[0-9]{2}-[0-9]{2}\n\n\* Item A\n\* Item B\n\n\[unreleased]: https:\/\/github\.com\/user\/project\/compare\/1\.0\.0\.\.\.HEAD\n\[1.0.0]: https:\/\/github\.com\/user\/project\/releases\/tag\/1\.0\.0\n$/
   );
 });

--- a/test.js
+++ b/test.js
@@ -245,7 +245,6 @@ test('should match an existing unreleased link in title case', async t => {
   );
 });
 
-// This test requires a change to runTasks, as it doesn't currently allow latestTag to be undefined/null.
 test('should add links to the end of a new changelog', async t => {
   const options = {
     [namespace]: { filename: 'CHANGELOG-VERSION_URL_NEW.md', addVersionUrl: true, strictLatest: false }

--- a/test.js
+++ b/test.js
@@ -23,6 +23,8 @@ mock({
   './CHANGELOG-UNRELEASED.md': '## [Unreleased]\n\n* Item A\n* Item B\n\n## [1.0.0] - 2020-05-02\n\n* Item C\n* Item D',
   './CHANGELOG-VERSION_URL.md':
     '## [Unreleased]\n\n* Item A\n* Item B\n\n## [1.0.0] - 2020-05-02\n\n* Item C\n* Item D\n\n[unreleased]: https://github.com/release-it/release-it/compare/1.0.0..HEAD\n[1.0.0]: https://github.com/release-it/release-it/compare/0.0.0...1.0.0',
+  './CHANGELOG-VERSION_URL_FORMATS.md':
+    '## [Unreleased]\n\n* Item A\n* Item B\n\n## [1.0.0] - 2020-05-02\n\n* Item C\n* Item D\n\n[unreleased]: https://github.com/_git/release-it/release-it/compareBranch/1.0.0/HEAD\n[1.0.0]: https://github.com/_git/release-it/release-it/compareBranch/0.0.0/1.0.0',
   './CHANGELOG-VERSION_URL_HEAD.md':
     '## [Unreleased]\n\n* Item A\n* Item B\n\n## [1.0.0] - 2020-05-02\n\n* Item C\n* Item D\n\n[unreleased]: https://github.com/release-it/release-it/compare/1.0.0..main\n[1.0.0]: https://github.com/release-it/release-it/compare/0.0.0...1.0.0',
   './CHANGELOG-VERSION_URL_UNRELEASED.md':
@@ -148,6 +150,34 @@ test('should add links to the end of the file', async t => {
   );
 });
 
+test('should add links with custom URL formats to the end of the file', async t => {
+  const options = {
+    [namespace]: {
+      filename: 'CHANGELOG-VERSION_URL_FORMATS.md',
+      addVersionUrl: true,
+      versionUrlFormats: {
+        repositoryUrl: 'https://{host}/_git/{repository}',
+        unreleasedUrl: '{repositoryUrl}/compareBranch/{tagName}/{head}',
+        versionUrl: '{repositoryUrl}/compareBranch/{previousTag}/{tagName}'
+      }
+    }
+  };
+  const plugin = factory(Plugin, { namespace, options });
+  plugin.config.setContext({
+    latestTag: '1.0.0',
+    repo: {
+      host: 'github.com',
+      repository: 'release-it/release-it'
+    }
+  });
+  await runTasks(plugin);
+  assert.equal(plugin.getChangelog(), '* Item A\n* Item B');
+  assert.match(
+    readFile('./CHANGELOG-VERSION_URL_FORMATS.md'),
+    /^## \[1\.0\.1] - [0-9]{4}-[0-9]{2}-[0-9]{2}\n\n\* Item A\n\* Item B\n\n## \[1\.0\.0] - 2020-05-02\n\n\* Item C\n*\* Item D\n\n\[unreleased]: https:\/\/github\.com\/_git\/release-it\/release-it\/compareBranch\/1\.0\.1\/HEAD\n\[1\.0\.1]: https:\/\/github\.com\/_git\/release-it\/release-it\/compareBranch\/1\.0\.0\/1\.0\.1\n\[1\.0\.0]: https:\/\/github\.com\/_git\/release-it\/release-it\/compareBranch\/0\.0\.0\/1\.0\.0\n$/
+  );
+});
+
 test('should add links with custom head to the end of the file', async t => {
   const options = { [namespace]: { filename: 'CHANGELOG-VERSION_URL_HEAD.md', addVersionUrl: true, head: 'main' } };
   const plugin = factory(Plugin, { namespace, options });
@@ -186,7 +216,8 @@ test('should add unreleased section and links to the end of the file', async t =
   );
 });
 
-test('should add links to the end of a new changelog', async t => {
+// This test requires a change to runTasks, as it doesn't currently allow latestTag to be undefined/null.
+test.skip('should add links to the end of a new changelog', async t => {
   const options = {
     [namespace]: { filename: 'CHANGELOG-VERSION_URL_NEW.md', addVersionUrl: true, strictLatest: false }
   };

--- a/test.js
+++ b/test.js
@@ -186,7 +186,7 @@ test('should add unreleased section and links to the end of the file', async t =
   );
 });
 
-test.only('should add links to the end of a new changelog', async t => {
+test('should add links to the end of a new changelog', async t => {
   const options = {
     [namespace]: { filename: 'CHANGELOG-VERSION_URL_NEW.md', addVersionUrl: true, strictLatest: false }
   };


### PR DESCRIPTION
Fixes #24.

This PR adds support for non-GitHub style version URLs via custom format strings. It also improves support for new changelogs, where the first released version should link to the tag rather than trying to compare to `null`.

Also renamed `[Unreleased]:` to `[unreleased]:` to match [Keep a Changelog](https://github.com/olivierlacan/keep-a-changelog/blob/main/CHANGELOG.md). This change is backwards-compatible as the plugin will now rename any existing `[Unreleased]` link as necessary.